### PR TITLE
Refactor LDAPSearchResult to use NULL to indicate EOF

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,11 @@ LDAP protocol support for the XP Framework ChangeLog
 
 ## ?.?.? / ????-??-??
 
+* **Heads up**: Changed LDAPSearchResult's getFirstEntry(), getEntry() &
+  getNextEntry() methods to return `NULL` instead of `FALSE` when EOF is
+  reached. While technically this is a BC break, it does not break the
+  iteration advertised in the README file. See xp-framework/ldap#4.
+  (@thekid)
 * Implemented xp-framework/ldap#3: LDAP entries iteration via `foreach`
   (@thekid)
 

--- a/src/main/php/peer/ldap/LDAPSearchResult.class.php
+++ b/src/main/php/peer/ldap/LDAPSearchResult.class.php
@@ -33,19 +33,19 @@ class LDAPSearchResult extends \lang\Object implements \Iterator {
   /**
    * Gets first entry
    *
-   * @return  peer.ldap.LDAPEntry or FALSE if nothing is found
+   * @return  peer.ldap.LDAPEntry or NULL if there is no first entry
    * @throws  peer.ldap.LDAPException in case of a read error
    */
   public function getFirstEntry() {
     $this->first= $this->entries->first();
-    return $this->first ?: false;
+    return $this->first;
   }
 
   /**
    * Get a search entry by resource
    *
    * @param   int offset
-   * @return  peer.ldap.LDAPEntry or FALSE if none exists by this offset
+   * @return  peer.ldap.LDAPEntry or NULL if none exists by this offset
    * @throws  peer.ldap.LDAPException in case of a read error
    */
   public function getEntry($offset) {
@@ -56,7 +56,7 @@ class LDAPSearchResult extends \lang\Object implements \Iterator {
       } while ($entry= $this->entries->next());
     }
     
-    return isset($this->all[$offset]) ? $this->all[$offset] : false;
+    return isset($this->all[$offset]) ? $this->all[$offset] : null;
   }
 
   /**
@@ -67,7 +67,7 @@ class LDAPSearchResult extends \lang\Object implements \Iterator {
    *   }
    * </code>
    *
-   * @return  peer.ldap.LDAPEntry or FALSE for EOF
+   * @return  peer.ldap.LDAPEntry or NULL for EOF
    * @throws  peer.ldap.LDAPException in case of a read error
    */
   public function getNextEntry() {
@@ -79,7 +79,7 @@ class LDAPSearchResult extends \lang\Object implements \Iterator {
       return $this->getFirstEntry();
     }
 
-    return $this->entries->next() ?: false;    
+    return $this->entries->next();    
   }
 
   /**

--- a/src/test/php/peer/ldap/unittest/LDAPSearchResultTest.class.php
+++ b/src/test/php/peer/ldap/unittest/LDAPSearchResultTest.class.php
@@ -45,7 +45,7 @@ class LDAPSearchResultTest extends \unittest\TestCase {
 
   #[@test]
   public function no_first_entry() {
-    $this->assertFalse((new LDAPSearchResult($this->newEntries()))->getFirstEntry());
+    $this->assertNull((new LDAPSearchResult($this->newEntries()))->getFirstEntry());
   }
 
   #[@test, @values([
@@ -61,7 +61,7 @@ class LDAPSearchResultTest extends \unittest\TestCase {
 
   #[@test]
   public function no_next_entry() {
-    $this->assertFalse((new LDAPSearchResult($this->newEntries()))->getNextEntry());
+    $this->assertNull((new LDAPSearchResult($this->newEntries()))->getNextEntry());
   }
 
   #[@test, @values([
@@ -103,7 +103,7 @@ class LDAPSearchResultTest extends \unittest\TestCase {
 
   #[@test]
   public function no_entry_zero() {
-    $this->assertFalse((new LDAPSearchResult($this->newEntries()))->getEntry(0));
+    $this->assertNull((new LDAPSearchResult($this->newEntries()))->getEntry(0));
   }
 
   #[@test, @values([


### PR DESCRIPTION
This fixes the "mixed" return type in getFirstEntry(), getEntry() and getNextEntry(). While technically this is a BC break it does not break the advertised iteration:

``` php
while ($entry= $res->getNextEntry()) {
  Console::writeLine('---> ', $entry->toString());
}
```

Also, this makes these methods usable in e.g. `util.data.Optional`.
