### PR TITLE
LDAPConnection class

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,11 @@ Example (LDAP search)
 ---------------------
 
 ```php
-use peer\ldap\LDAPClient;
+use peer\ldap\LDAPConnection;
 use util\cmd\Console;
 
-$l= new LDAPClient('ldap.openldap.org');
-$l->setOption(LDAP_OPT_PROTOCOL_VERSION, 3);
+$l= new LDAPConnection('ldap://ldap.example.com');
 $l->connect();
-$l->bind();
 
 $search= $l->search(
   'ou=People,dc=OpenLDAP,dc=Org', 
@@ -40,13 +38,11 @@ Example (Modifying an entry)
 ----------------------------
 
 ```php
-use peer\ldap\LDAPClient;
+use peer\ldap\LDAPConnection;
 use peer\ldap\LDAPEntry;
 
-$l= new LDAPClient('ldap.example.com');
-$l->setOption(LDAP_OPT_PROTOCOL_VERSION, 3);
+$l= new LDAPConnection('ldap://uid=admin,o=roles,dc=planet-xp,dc=net:password@ldap.example.com');
 $l->connect();
-$l->bind('uid=admin,o=roles,dc=planet-xp,dc=net', 'password');
 
 with ($entry= $l->read(new LDAPEntry('uid=1549,o=people,dc=planet-xp,dc=net'))); {
   $entry->setAttribute('firstname', 'Timm');
@@ -61,13 +57,11 @@ Example (Adding an entry)
 -------------------------
 
 ```php
-use peer\ldap\LDAPClient;
+use peer\ldap\LDAPConnection;
 use peer\ldap\LDAPEntry;
 
-$l= new LDAPClient('ldap.example.com');
-$l->setOption(LDAP_OPT_PROTOCOL_VERSION, 3);
+$l= new LDAPConnection('ldap://uid=admin,o=roles,dc=planet-xp,dc=net:password@ldap.example.com');
 $l->connect();
-$l->bind('uid=admin,o=roles,dc=planet-xp,dc=net', 'password');
 
 with ($entry= new LDAPEntry('uid=1549,o=people,dc=planet-xp,dc=net')); {
   $entry->setAttribute('uid', 1549);

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^7.0 | ^6.5",
+    "xp-framework/networking": "^7.0 | ^6.6",
     "php" : ">=5.5.0"
   },
   "require-dev" : {

--- a/src/main/php/peer/ldap/LDAPClient.class.php
+++ b/src/main/php/peer/ldap/LDAPClient.class.php
@@ -41,6 +41,7 @@ use peer\ConnectException;
  *   $l->close();
  * </code>
  *
+ * @deprecated Use LDAPConnection instead
  * @see      php://ldap
  * @see      http://developer.netscape.com/docs/manuals/directory/41/ag/
  * @see      http://developer.netscape.com/docs/manuals/dirsdk/jsdk40/contents.htm

--- a/src/main/php/peer/ldap/LDAPConnection.class.php
+++ b/src/main/php/peer/ldap/LDAPConnection.class.php
@@ -95,6 +95,8 @@ class LDAPConnection extends \lang\Object {
     }
 
     if (false === ldap_bind($this->handle, $this->url->getUser(null), $this->url->getPassword(null))) {
+      ldap_unbind($this->handle);
+      $this->handle= null;
       switch ($error= ldap_errno($this->handle)) {
         case -1: case LDAP_SERVER_DOWN:
           throw new ConnectException('Cannot connect to '.$uri);

--- a/src/main/php/peer/ldap/LDAPConnection.class.php
+++ b/src/main/php/peer/ldap/LDAPConnection.class.php
@@ -90,7 +90,7 @@ class LDAPConnection extends \lang\Object {
       if (!self::$options[$option]($this->handle, $value)) {
         ldap_unbind($this->handle);
         $this->handle= null;
-        throw new LDAPException('Cannot set value "'.$option.'"', ldap_errno($this->handle));
+        throw new LDAPException('Cannot set option "'.$option.'"', ldap_errno($this->handle));
       }
     }
 

--- a/src/main/php/peer/ldap/LDAPConnection.class.php
+++ b/src/main/php/peer/ldap/LDAPConnection.class.php
@@ -68,8 +68,8 @@ class LDAPConnection extends \lang\Object {
   /**
    * Connect to the LDAP server
    *
-   * @return  resource LDAP resource handle
-   * @throws  peer.ConnectException
+   * @return self $this
+   * @throws peer.ConnectException
    */
   public function connect() {
     static $ports= ['ldap' => 389, 'ldaps' => 636];
@@ -112,7 +112,7 @@ class LDAPConnection extends \lang\Object {
   /**
    * Checks whether the connection is open
    *
-   * @return  bool
+   * @return bool
    */
   public function isConnected() {
     return is_resource($this->handle);

--- a/src/main/php/peer/ldap/LDAPConnection.class.php
+++ b/src/main/php/peer/ldap/LDAPConnection.class.php
@@ -1,0 +1,323 @@
+<?php namespace peer\ldap;
+
+use peer\ConnectException;
+use peer\URL;
+use lang\XPClass;
+use lang\lang\IllegalArgumentException;
+
+/**
+ * LDAP connection
+ * 
+ * @see   php://ldap
+ * @see   http://developer.netscape.com/docs/manuals/directory/41/ag/
+ * @see   http://developer.netscape.com/docs/manuals/dirsdk/jsdk40/contents.htm
+ * @see   http://perl-ldap.sourceforge.net/doc/Net/LDAP/
+ * @see   http://ldap.akbkhome.com/
+ * @see   rfc://2251
+ * @see   rfc://2252
+ * @see   rfc://2253
+ * @see   rfc://2254
+ * @see   rfc://2255
+ * @see   rfc://2256
+ * @ext   ldap
+ * @test  xp://net.xp_framework.unittest.peer.LDAPTest
+ */
+class LDAPConnection extends \lang\Object {
+  private $url;
+  private $handle= null;
+
+  static function __static() {
+    XPClass::forName('peer.ldap.LDAPException');  // Error codes
+  }
+
+  /**
+   * Create a new connection from a given DSN of the form:
+   * `ldap://user:pass@host:port/?options[protocol_version]=2`
+   *
+   * @param   string|peer.URL $dsn
+   */
+  public function __construct($dsn) {
+    $this->url= $dsn instanceof URL ? $dsn : new URL($dsn);
+  }
+
+  /**
+   * Connect to the LDAP server
+   *
+   * @return  resource LDAP resource handle
+   * @throws  peer.ConnectException
+   */
+  public function connect() {
+    if ($this->isConnected()) return true;
+
+    if (false === ($this->handle= ldap_connect($this->url->getHost(), $this->url->getPort(389)))) {
+      throw new ConnectException('Cannot connect to '.$this->url->getHost().':'.$this->url->getPort(389));
+    }
+    
+    if (false === ldap_bind($this->handle, $this->url->getUser(null), $this->url->getPassword(null))) {
+      switch ($error= ldap_errno($this->handle)) {
+        case -1: case LDAP_SERVER_DOWN:
+          throw new ConnectException('Cannot connect to '.$this->url->getHost().':'.$this->url->getPort(389));
+        
+        default:
+          throw new LDAPException('Cannot bind for "'.$this->url->getUser(null).'"', $error);
+      }
+    }
+
+    foreach (array_merge(['protocol_version' => 3], $this->url->getParam('options')) as $option => $value) {
+      if (false === ldap_set_option($this->handle, constant('LDAP_OPT_'.strtoupper($option), $value))) {
+        ldap_unbind($this->handle);
+        $this->handle= null;
+        throw new LDAPException('Cannot set value "'.$option.'"', ldap_errno($this->handle));
+      }
+    }
+
+    return $this;
+  }
+
+  /**
+   * Checks whether the connection is open
+   *
+   * @return  bool
+   */
+  public function isConnected() {
+    return is_resource($this->handle);
+  }
+  
+  /**
+   * Closes the connection
+   *
+   * @see     php://ldap_close
+   */
+  public function close() {
+    if ($this->handle) {
+      ldap_unbind($this->handle);
+      $this->handle= null;
+    }
+  }
+
+  /**
+   * Perform an LDAP search with scope LDAP_SCOPE_SUB
+   *
+   * @param   string base_dn
+   * @param   string filter
+   * @param   array attributes default []
+   * @param   int attrsonly default 0,
+   * @param   int sizelimit default 0
+   * @param   int timelimit default 0 Time limit, 0 means no limit
+   * @param   int deref one of LDAP_DEREF_*
+   * @return  peer.ldap.LDAPSearchResult search result object
+   * @throws  peer.ldap.LDAPException
+   * @see     php://ldap_search
+   */
+  public function search() {
+    $args= func_get_args();
+    array_unshift($args, $this->handle);
+    if (false === ($res= call_user_func_array('ldap_search', $args))) {
+      throw new LDAPException('Search failed', ldap_errno($this->handle));
+    }
+    
+    return new LDAPSearchResult(new LDAPEntries($this->handle, $res));
+  }
+  
+  /**
+   * Perform an LDAP search specified by a given filter.
+   *
+   * @param   peer.ldap.LDAPQuery filter
+   * @return  peer.ldap.LDAPSearchResult search result object
+   */
+  public function searchBy(LDAPQuery $filter) {
+    static $methods= [
+      LDAPQuery::SCOPE_BASE     => 'ldap_read',
+      LDAPQuery::SCOPE_ONELEVEL => 'ldap_list',
+      LDAPQuery::SCOPE_SUB      => 'ldap_search'
+    ];
+    
+    if (!isset($methods[$filter->getScope()]))
+      throw new \lang\IllegalArgumentException('Scope '.$args[0].' not supported');
+    
+    if (false === ($res= @call_user_func_array(
+      $methods[$filter->getScope()], array(
+      $this->handle,
+      $filter->getBase(),
+      $filter->getFilter(),
+      $filter->getAttrs(),
+      $filter->getAttrsOnly(),
+      $filter->getSizeLimit(),
+      $filter->getTimelimit(),
+      $filter->getDeref()
+    )))) {
+      throw new LDAPException('Search failed', ldap_errno($this->handle));
+    }
+
+    // Sort results by given sort attributes
+    if ($filter->getSort()) foreach ($filter->getSort() as $sort) {
+      ldap_sort($this->handle, $res, $sort);
+    }
+    return new LDAPSearchResult(new LDAPEntries($this->handle, $res));
+  }
+  
+  /**
+   * Read an entry
+   *
+   * @param   peer.ldap.LDAPEntry entry specifying the dn
+   * @return  peer.ldap.LDAPEntry entry
+   * @throws  lang.IllegalArgumentException
+   * @throws  peer.ldap.LDAPException
+   */
+  public function read(LDAPEntry $entry) {
+    $res= ldap_read($this->handle, $entry->getDN(), 'objectClass=*', [], false, 0);
+    if (LDAP_SUCCESS != ldap_errno($this->handle)) {
+      throw new LDAPException('Read "'.$entry->getDN().'" failed', ldap_errno($this->handle));
+    }
+
+    $entry= ldap_first_entry($this->handle, $res);
+    return LDAPEntry::create(ldap_get_dn($this->handle, $entry), ldap_get_attributes($this->handle, $entry));
+  }
+  
+  /**
+   * Check if an entry exists
+   *
+   * @param   peer.ldap.LDAPEntry entry specifying the dn
+   * @return  bool TRUE if the entry exists
+   */
+  public function exists(LDAPEntry $entry) {
+    $res= ldap_read($this->handle, $entry->getDN(), 'objectClass=*', [], false, 0);
+    
+    // Check for certain error code (#32)
+    if (LDAP_NO_SUCH_OBJECT === ldap_errno($this->handle)) {
+      return false;
+    }
+    
+    // Check for other errors
+    if (LDAP_SUCCESS != ldap_errno($this->handle)) {
+      throw new LDAPException('Read "'.$entry->getDN().'" failed', ldap_errno($this->handle));
+    }
+    
+    // No errors occurred, requested object exists
+    ldap_free_result($res);
+    return true;
+  }
+  
+  /**
+   * Add an entry
+   *
+   * @param   peer.ldap.LDAPEntry entry
+   * @return  bool success
+   * @throws  lang.IllegalArgumentException when entry parameter is not an LDAPEntry object
+   * @throws  peer.ldap.LDAPException when an error occurs during adding the entry
+   */
+  public function add(LDAPEntry $entry) {
+    
+    // This actually returns NULL on failure, not FALSE, as documented
+    if (null == ($res= ldap_add(
+      $this->handle, 
+      $entry->getDN(), 
+      $entry->getAttributes()
+    ))) {
+      throw new LDAPException('Add for "'.$entry->getDN().'" failed', ldap_errno($this->handle));
+    }
+    
+    return $res;
+  }
+
+  /**
+   * Modify an entry. 
+   *
+   * Note: Will do a complete update of all fields and can be quite slow
+   * TBD(?): Be more intelligent about what to update?
+   *
+   * @param   peer.ldap.LDAPEntry entry
+   * @return  bool success
+   * @throws  lang.IllegalArgumentException when entry parameter is not an LDAPEntry object
+   * @throws  peer.ldap.LDAPException when an error occurs during adding the entry
+   */
+  public function modify(LDAPEntry $entry) {
+    if (false == ($res= ldap_modify(
+      $this->handle,
+      $entry->getDN(),
+      $entry->getAttributes()
+    ))) {
+      throw new LDAPException('Modify for "'.$entry->getDN().'" failed', ldap_errno($this->handle));
+    }
+    
+    return $res;
+  }
+
+  /**
+   * Delete an entry
+   *
+   * @param   peer.ldap.LDAPEntry entry
+   * @return  bool success
+   * @throws  lang.IllegalArgumentException when entry parameter is not an LDAPEntry object
+   * @throws  peer.ldap.LDAPException when an error occurs during adding the entry
+   */
+  public function delete(LDAPEntry $entry) {
+    if (false == ($res= ldap_delete(
+      $this->handle,
+      $entry->getDN()
+    ))) {
+      throw new LDAPException('Delete for "'.$entry->getDN().'" failed', ldap_errno($this->handle));
+    }
+    
+    return $res;
+  }
+
+  /**
+   * Add an attribute to an entry
+   *
+   * @param   peer.ldap.LDAPEntry entry
+   * @param   string name
+   * @param   var value
+   * @return  bool
+   */
+  public function addAttribute(LDAPEntry $entry, $name, $value) {
+    if (false == ($res= ldap_mod_add(
+      $this->handle,
+      $entry->getDN(),
+      [$name => $value]
+    ))) {
+      throw new LDAPException('Add attribute for "'.$entry->getDN().'" failed', ldap_errno($this->handle));
+    }
+    
+    return $res;
+  }
+
+  /**
+   * Delete an attribute from an entry
+   *
+   * @param   peer.ldap.LDAPEntry entry
+   * @param   string name
+   * @return  bool
+   */
+  public function deleteAttribute(LDAPEntry $entry, $name) {
+    if (false == ($res= ldap_mod_del(
+      $this->handle,
+      $entry->getDN(),
+      $name
+    ))) {
+      throw new LDAPException('Delete attribute for "'.$entry->getDN().'" failed', ldap_errno($this->handle));
+    }
+    
+    return $res;
+  }
+
+  /**
+   * Add an attribute to an entry
+   *
+   * @param   peer.ldap.LDAPEntry entry
+   * @param   string name
+   * @param   var value
+   * @return  bool
+   */
+  public function replaceAttribute(LDAPEntry $entry, $name, $value) {
+    if (false == ($res= ldap_mod_replace(
+      $this->handle,
+      $entry->getDN(),
+      [$name => $value]
+    ))) {
+      throw new LDAPException('Replace attribute for "'.$entry->getDN().'" failed', ldap_errno($this->handle));
+    }
+    
+    return $res;
+  }
+}

--- a/src/main/php/peer/ldap/LDAPQuery.class.php
+++ b/src/main/php/peer/ldap/LDAPQuery.class.php
@@ -6,17 +6,20 @@
  * @see     xp://peer.ldap.LDAPClient
  * @see     rfc://2254
  * @test    xp://net.xp_framework.unittest.peer.LDAPQueryTest
- * @purpose Wrap LDAP queries
  */
 class LDAPQuery extends \lang\Object {
-  const RECEIVE_TYPES=  1;
-  const RECEIVE_VALUES= 0;
+  const RECEIVE_TYPES  = 1;
+  const RECEIVE_VALUES = 0;
+
+  const SCOPE_BASE     = 0x0000;
+  const SCOPE_ONELEVEL = 0x0001;
+  const SCOPE_SUB      = 0x0002;
 
   public
     $filter=      '',
     $scope=       0,
     $base=        '',
-    $attrs=       array(),
+    $attrs=       [],
     $attrsOnly=   self::RECEIVE_VALUES,
     $sizelimit=   0,
     $timelimit=   0,

--- a/src/main/php/peer/ldap/LDAPQuery.class.php
+++ b/src/main/php/peer/ldap/LDAPQuery.class.php
@@ -111,10 +111,12 @@ class LDAPQuery extends \lang\Object {
    * Set Filter
    *
    * @param   string filter
+   * @return  self $this
    */
   public function setFilter() {
     $args= func_get_args();
     $this->filter= $this->_prepare($args);
+    return $this;
   }
 
   /**
@@ -130,9 +132,11 @@ class LDAPQuery extends \lang\Object {
    * Set Scope
    *
    * @param   int scope
+   * @return  self $this
    */
   public function setScope($scope) {
     $this->scope= $scope;
+    return $this;
   }
 
   /**
@@ -148,10 +152,12 @@ class LDAPQuery extends \lang\Object {
    * Set Base
    *
    * @param   var[] args
+   * @return  self $this
    */
   public function setBase() {
     $args= func_get_args();
     $this->base= $this->_prepare($args);
+    return $this;
   }
 
   /**
@@ -176,9 +182,11 @@ class LDAPQuery extends \lang\Object {
    * Set Attrs
    *
    * @param   var[] attrs
+   * @return  self $this
    */
   public function setAttrs($attrs) {
     $this->attrs= $attrs;
+    return $this;
   }
 
   /**
@@ -194,9 +202,11 @@ class LDAPQuery extends \lang\Object {
    * Set whether to return only attribute types.
    *
    * @param  bool mode
+   * @return  self $this
    */
   public function setAttrsOnly($mode) {
     $this->attrsOnly= $mode;
+    return $this;
   }
 
   /**
@@ -212,9 +222,11 @@ class LDAPQuery extends \lang\Object {
    * Set Sizelimit
    *
    * @param   int sizelimit
+   * @return  self $this
    */
   public function setSizelimit($sizelimit) {
     $this->sizelimit= $sizelimit;
+    return $this;
   }
 
   /**
@@ -230,9 +242,11 @@ class LDAPQuery extends \lang\Object {
    * Set Timelimit
    *
    * @param   int timelimit
+   * @return  self $this
    */
   public function setTimelimit($timelimit) {
     $this->timelimit= $timelimit;
+    return $this;
   }
 
   /**
@@ -251,9 +265,11 @@ class LDAPQuery extends \lang\Object {
    *
    * @see     php://ldap_sort
    * @param   string[] sort array of fields to sort with
+   * @return  self $this
    */
   public function setSort($sort) {
     $this->sort= $sort;
+    return $this;
   }
 
   /**
@@ -269,8 +285,10 @@ class LDAPQuery extends \lang\Object {
    * Set Deref
    *
    * @param   bool deref
+   * @return  self $this
    */
   public function setDeref($deref) {
+    return $this;
     $this->deref= $deref;
   }
 

--- a/src/test/php/peer/ldap/unittest/LDAPConnectionTest.class.php
+++ b/src/test/php/peer/ldap/unittest/LDAPConnectionTest.class.php
@@ -1,0 +1,35 @@
+<?php namespace peer\ldap\unittest;
+
+use peer\ldap\LDAPConnection;
+use peer\URL;
+use lang\IllegalArgumentException;
+
+class LDAPConnectionTest extends \unittest\TestCase {
+
+  /** @return var[][] */
+  private function dsns() {
+    return [
+      ['ldap://example.com'],
+      ['ldap://example.com:389'],
+      ['ldap://bind-dn:password@example.com'],
+      ['ldap://bind-dn:password@example.com:389'],
+      ['ldap://example.com/?protocol_version=2'],
+      ['ldap://example.com/?protocol_version=2&network_timeout=30']
+    ];
+  }
+
+  #[@test, @values('dsns')]
+  public function can_create_from_dsn_string($dsn) {
+    new LDAPConnection($dsn);
+  }
+
+  #[@test, @values('dsns')]
+  public function can_create_from_dsn_url($dsn) {
+    new LDAPConnection(new URL($dsn));
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function unknown_option() {
+    new LDAPConnection('ldap://example.com/?unkown=value');
+  }
+}

--- a/src/test/php/peer/ldap/unittest/LDAPConnectionTest.class.php
+++ b/src/test/php/peer/ldap/unittest/LDAPConnectionTest.class.php
@@ -11,6 +11,8 @@ class LDAPConnectionTest extends \unittest\TestCase {
     return [
       ['ldap://example.com'],
       ['ldap://example.com:389'],
+      ['ldaps://example.com'],
+      ['ldaps://example.com:636'],
       ['ldap://bind-dn:password@example.com'],
       ['ldap://bind-dn:password@example.com:389'],
       ['ldap://example.com/?protocol_version=2'],


### PR DESCRIPTION
Implements xp-framework/rfc#147 and creates a new `peer.ldap.LDAPConnection` class:
## Simpler setup

Setting up an LDAP connection requires much less boilerplate now

Before:

``` php
// Anonymous
$l= new LDAPClient('ldap.openldap.org');
$l->setOption(LDAP_OPT_PROTOCOL_VERSION, 3);
$l->connect();
$l->bind();

// With user and password
$l= new LDAPClient('ldap.openldap.org');
$l->setOption(LDAP_OPT_PROTOCOL_VERSION, 3);
$l->connect();
$l->bind('uid=admin,o=roles,dc=planet-xp,dc=net', 'password');
```

After: Protocol version 3 has become the default, connect directly binds (passing credentials if necessary):

``` php
// Anonymous
$l= new LDAPConnection('ldap://ldap.openldap.org');
$l->connect();

// With user and password
$l= new LDAPConnection('ldap://uid=admin,o=roles,dc=planet-xp,dc=net:password@ldap.example.com');
$l->connect();
```
## More changes
- The LDAPClient class is now deprecated in favor of LDAPConnection - the documentation only advertises the latter.
- The `connect()` method returns $this, so you can use it in a fluent style.
- All other methods continue to be supported with the exception of `searchScope()` (which has been superseded by `searchBy()`).
