### PR TITLE
Add accessor for underlying connection DSN

### DIFF
--- a/src/main/php/peer/ldap/LDAPConnection.class.php
+++ b/src/main/php/peer/ldap/LDAPConnection.class.php
@@ -65,6 +65,9 @@ class LDAPConnection extends \lang\Object {
     }
   }
 
+  /** @return peer.URL */
+  public function dsn() { return $this->url; }
+
   /**
    * Connect to the LDAP server
    *

--- a/src/test/php/peer/ldap/unittest/LDAPConnectionTest.class.php
+++ b/src/test/php/peer/ldap/unittest/LDAPConnectionTest.class.php
@@ -34,4 +34,9 @@ class LDAPConnectionTest extends \unittest\TestCase {
   public function unknown_option() {
     new LDAPConnection('ldap://example.com/?unkown=value');
   }
+
+  #[@test]
+  public function dsn() {
+    $this->assertEquals(new URL('ldap://example.com'), (new LDAPConnection('ldap://example.com'))->dsn());
+  }
 }


### PR DESCRIPTION
Instead of having to either remember it or to access it using this hack:

``` php
$dsn= typeof($conn)->getField('url')->setAccessible(true)->get($conn);
```
