### PR TITLE
Detect disconnects

### DIFF
--- a/src/main/php/peer/ldap/LDAPConnection.class.php
+++ b/src/main/php/peer/ldap/LDAPConnection.class.php
@@ -216,7 +216,7 @@ class LDAPConnection extends \lang\Object {
       $filter->getTimelimit(),
       $filter->getDeref()
     ))) {
-      throw throw $this->error('Search failed');
+      throw $this->error('Search failed');
     }
 
     // Sort results by given sort attributes

--- a/src/main/php/peer/ldap/LDAPConnection.class.php
+++ b/src/main/php/peer/ldap/LDAPConnection.class.php
@@ -202,7 +202,7 @@ class LDAPConnection extends \lang\Object {
     ];
     
     if (!isset($methods[$filter->getScope()])) {
-      throw new \lang\IllegalArgumentException('Scope '.$args[0].' not supported');
+      throw new IllegalArgumentException('Scope '.$filter->getScope().' not supported');
     }
 
     $f= $methods[$filter->getScope()];

--- a/src/main/php/peer/ldap/LDAPConnection.class.php
+++ b/src/main/php/peer/ldap/LDAPConnection.class.php
@@ -182,7 +182,7 @@ class LDAPConnection extends \lang\Object {
       $timelimit,
       $deref
     ))) {
-      $this->error('Search failed');
+      throw $this->error('Search failed');
     }
     
     return new LDAPSearchResult(new LDAPEntries($this->handle, $res));
@@ -216,7 +216,7 @@ class LDAPConnection extends \lang\Object {
       $filter->getTimelimit(),
       $filter->getDeref()
     ))) {
-      throw $this->error('Search failed');
+      throw throw $this->error('Search failed');
     }
 
     // Sort results by given sort attributes
@@ -237,7 +237,7 @@ class LDAPConnection extends \lang\Object {
   public function read(LDAPEntry $entry) {
     $res= ldap_read($this->handle, $entry->getDN(), 'objectClass=*', [], false, 0);
     if (LDAP_SUCCESS != ldap_errno($this->handle)) {
-      $this->error('Read "'.$entry->getDN().'" failed');
+      throw $this->error('Read "'.$entry->getDN().'" failed');
     }
 
     $entry= ldap_first_entry($this->handle, $res);
@@ -260,7 +260,7 @@ class LDAPConnection extends \lang\Object {
     
     // Check for other errors
     if (LDAP_SUCCESS != ldap_errno($this->handle)) {
-      $this->error('Read "'.$entry->getDN().'" failed');
+      throw $this->error('Read "'.$entry->getDN().'" failed');
     }
     
     // No errors occurred, requested object exists
@@ -284,7 +284,7 @@ class LDAPConnection extends \lang\Object {
       $entry->getDN(), 
       $entry->getAttributes()
     ))) {
-      $this->error('Add for "'.$entry->getDN().'" failed');
+      throw $this->error('Add for "'.$entry->getDN().'" failed');
     }
     
     return $res;
@@ -307,7 +307,7 @@ class LDAPConnection extends \lang\Object {
       $entry->getDN(),
       $entry->getAttributes()
     ))) {
-      $this->error('Modify for "'.$entry->getDN().'" failed');
+      throw $this->error('Modify for "'.$entry->getDN().'" failed');
     }
     
     return $res;
@@ -326,7 +326,7 @@ class LDAPConnection extends \lang\Object {
       $this->handle,
       $entry->getDN()
     ))) {
-      $this->error('Delete for "'.$entry->getDN().'" failed');
+      throw $this->error('Delete for "'.$entry->getDN().'" failed');
     }
     
     return $res;
@@ -346,7 +346,7 @@ class LDAPConnection extends \lang\Object {
       $entry->getDN(),
       [$name => $value]
     ))) {
-      $this->error('Add attribute for "'.$entry->getDN().'" failed');
+      throw $this->error('Add attribute for "'.$entry->getDN().'" failed');
     }
     
     return $res;
@@ -365,7 +365,7 @@ class LDAPConnection extends \lang\Object {
       $entry->getDN(),
       $name
     ))) {
-      $this->error('Delete attribute for "'.$entry->getDN().'" failed');
+      throw $this->error('Delete attribute for "'.$entry->getDN().'" failed');
     }
     
     return $res;
@@ -385,7 +385,7 @@ class LDAPConnection extends \lang\Object {
       $entry->getDN(),
       [$name => $value]
     ))) {
-      $this->error('Replace attribute for "'.$entry->getDN().'" failed');
+      throw $this->error('Replace attribute for "'.$entry->getDN().'" failed');
     }
     
     return $res;

--- a/src/main/php/peer/ldap/LDAPConnection.class.php
+++ b/src/main/php/peer/ldap/LDAPConnection.class.php
@@ -153,8 +153,10 @@ class LDAPConnection extends \lang\Object {
     if (LDAP_SERVER_DOWN === $error || -1 === $error) {
       ldap_unbind($this->handle);
       $this->handle= null;
+      return new LDAPDisconnected($message, $error);
+    } else {
+      return new LDAPException($message, $error);
     }
-    return new LDAPException($message, $error);
   }
 
   /**

--- a/src/main/php/peer/ldap/LDAPDisconnected.class.php
+++ b/src/main/php/peer/ldap/LDAPDisconnected.class.php
@@ -1,0 +1,7 @@
+<?php namespace peer\ldap;
+
+/**
+ * Indicate the LDAP connection was closed from the server-side
+ */
+class LDAPDisconnected extends LDAPException {
+}

--- a/src/main/php/peer/ldap/LDAPException.class.php
+++ b/src/main/php/peer/ldap/LDAPException.class.php
@@ -70,8 +70,7 @@ define('LDAP_REFERRAL_LIMIT_EXCEEDED',         0x0061);
  * @see      http://developer.netscape.com/docs/manuals/dirsdk/jsdk40/Reference/netscape/ldap/LDAPException.html
  */
 class LDAPException extends \lang\XPException {
-  public
-    $errorcode = 0;
+  public $errorcode;
     
   /**
    * Constructor
@@ -82,6 +81,15 @@ class LDAPException extends \lang\XPException {
   public function __construct($message, $errorcode) {
     parent::__construct($message);
     $this->errorcode= $errorcode;
+  }
+
+  /**
+   * Check whether a disconnect was received
+   *
+   * @return  bool
+   */
+  public function disconnected() {
+    return LDAP_SERVER_DOWN === $this->errorcode || -1 === $this->errorcode;
   }
 
   /**

--- a/src/main/php/peer/ldap/LDAPException.class.php
+++ b/src/main/php/peer/ldap/LDAPException.class.php
@@ -84,15 +84,6 @@ class LDAPException extends \lang\XPException {
   }
 
   /**
-   * Check whether a disconnect was received
-   *
-   * @return  bool
-   */
-  public function disconnected() {
-    return LDAP_SERVER_DOWN === $this->errorcode || -1 === $this->errorcode;
-  }
-
-  /**
    * Get errorcode
    *
    * @return  int


### PR DESCRIPTION
### Previously

``` php
for ($tries= 1;;) {
  try {
    $search= $conn->search('o=people,dc=example,dc=com', '(uid=1549)');
    break;
  } catch (LDAPException $e) {
    if (-1 === $e->getErrorCode() || LDAP_SERVER_DOWN === $e->getErrorCode()) {
      $conn->close();
      if (0 === $tries--) throw $e;
      $conn->connect();   // Reconnect!
    } else {
      throw $e;
    }
  }
}
```
### Now

``` php
for ($tries= 1;;) {
  try {
    $search= $conn->search('o=people,dc=example,dc=com', '(uid=1549)');
    break;
  } catch (LDAPDisconnected $e) {
    if (0 === $tries--) throw $e;
    $conn->connect();   // Reconnect!
  }
}
```
## BC

The `peer.ldap.LDAPDisconnected` class is a `peer.ldap.LDAPException` so the above code continues to work, although it is of course less efficient 😁 
