### PR TITLE
Special exceptions for LDAP_NO_SUCH_OBJECT

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,13 @@ LDAP protocol support for the XP Framework ChangeLog
 
 ## ?.?.? / ????-??-??
 
+## 8.1.0 / 2018-06-06
+
+* Added `peer.ldap.LDAPNoSuchObject` exception for `LDAP_NO_SUCH_OBJECT`
+  errors. This is useful when performing searches on subtrees that exist
+  in 99.9% of all cases, so we don't check them beforehand.
+  (@thekid)
+
 ## 8.0.1 / 2018-04-02
 
 * Fixed compatiblity with PHP 7.2 - @thekid

--- a/src/main/php/peer/ldap/LDAPConnection.class.php
+++ b/src/main/php/peer/ldap/LDAPConnection.class.php
@@ -150,12 +150,17 @@ class LDAPConnection {
    */
   private function error($message) {
     $error= ldap_errno($this->handle);
-    if (LDAP_SERVER_DOWN === $error || -1 === $error) {
-      ldap_unbind($this->handle);
-      $this->handle= null;
-      return new LDAPDisconnected($message, $error);
-    } else {
-      return new LDAPException($message, $error);
+    switch ($error) {
+      case -1: case LDAP_SERVER_DOWN:
+        ldap_unbind($this->handle);
+        $this->handle= null;
+        return new LDAPDisconnected($message, $error);
+
+      case LDAP_NO_SUCH_OBJECT:
+        return new LDAPNoSuchObject($message, $error);
+    
+      default:  
+        return new LDAPException($message, $error);
     }
   }
 

--- a/src/main/php/peer/ldap/LDAPNoSuchObject.class.php
+++ b/src/main/php/peer/ldap/LDAPNoSuchObject.class.php
@@ -1,0 +1,7 @@
+<?php namespace peer\ldap;
+
+/**
+ * LDAP_NO_SUCH_OBJECT
+ */
+class LDAPNoSuchObject extends LDAPException {
+}


### PR DESCRIPTION
This is useful when performing searches on subtrees that exist in 99.9% of all cases, so we don't check them beforehand.

```php
try {
  $res= $ldap->search(sprintf('uid=%d,ou=Rights,%s', $userId, $base), '(objectClass=rightObject)');
} catch (LDAPNoSuchObject $e) {
  // E.g. the subtree uid=XXX under ou=Rights does not exist
}
```
